### PR TITLE
Refine portfolio content and expand project details

### DIFF
--- a/index.html
+++ b/index.html
@@ -86,7 +86,7 @@
                         Construyo plataformas digitales confiables y listas para producción.
                     </h1>
                     <p class="max-w-2xl text-lg text-slate-600">
-                        Soy Nicolás Álvarez, ingeniero de software. Creo productos con foco en automatización, escalabilidad y experiencia de usuario, alineando la visión de negocio con implementaciones sólidas.
+                        Soy Nicolás Álvarez, ingeniero de software en mi último año de carrera. Tras dos años de especialización universitaria en ciberseguridad aplicada, diseño productos que combinan automatización, escalabilidad y buenas prácticas de seguridad.
                     </p>
                     <div class="flex flex-wrap items-center gap-4">
                         <a href="#projects" class="inline-flex items-center justify-center gap-2 rounded-full bg-blue-600 px-6 py-3 text-sm font-semibold text-white shadow-lg shadow-blue-600/20 transition hover:bg-blue-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600">
@@ -110,19 +110,19 @@
                         <div class="absolute -bottom-20 -left-10 h-56 w-56 rounded-full bg-amber-100 blur-3xl"></div>
                         <div class="relative space-y-6">
                             <p class="text-sm font-medium uppercase tracking-[0.3em] text-slate-400">Resumen Express</p>
-                            <p class="text-xl font-semibold text-slate-800">Transformo flujos críticos en plataformas seguras, medibles y automatizadas.</p>
+                            <p class="text-xl font-semibold text-slate-800">Diseño y desarrollo plataformas web seguras, escalables y bien estructuradas.</p>
                             <ul class="space-y-4 text-sm text-slate-600">
                                 <li class="flex items-start gap-3">
                                     <span class="mt-1 h-2 w-2 rounded-full bg-blue-500"></span>
-                                    Lidero productos end-to-end con stacks basados en Python, JavaScript y ecosistemas cloud.
+                                    Especialista en backend Python con Flask y FastAPI, apoyado en tareas asíncronas con Celery y bases de datos relacionales.
                                 </li>
                                 <li class="flex items-start gap-3">
                                     <span class="mt-1 h-2 w-2 rounded-full bg-blue-500"></span>
-                                    Diseño procesos con observabilidad, despliegues reproducibles y enfoque DevSecOps.
+                                    Construyo interfaces limpias con JavaScript y React ligero cuando aporta valor a la experiencia.
                                 </li>
                                 <li class="flex items-start gap-3">
                                     <span class="mt-1 h-2 w-2 rounded-full bg-blue-500"></span>
-                                    Construyo experiencias limpias que comunican valor de negocio sin sacrificar detalle técnico.
+                                    Aplico buenas prácticas de ciberseguridad en autenticación, despliegues y protección de datos.
                                 </li>
                             </ul>
                         </div>
@@ -136,12 +136,12 @@
             <div class="mx-auto flex w-full max-w-6xl flex-col gap-12 px-6 lg:flex-row">
                 <div class="w-full space-y-6 lg:w-2/3" data-animate>
                     <p class="text-xs font-semibold uppercase tracking-[0.3em] text-slate-500">Sobre mí</p>
-                    <h2 class="text-3xl font-semibold text-slate-900 sm:text-4xl">Estrategia, diseño técnico y entrega disciplinada.</h2>
+                    <h2 class="text-3xl font-semibold text-slate-900 sm:text-4xl">Formación técnica con foco en seguridad aplicada.</h2>
                     <p class="text-lg text-slate-600">
-                        Soy ingeniero de software en mi último año de carrera, con una especialización universitaria de dos años en ciberseguridad aplicada. Me gusta combinar creatividad y tecnología para transformar operaciones complejas en productos claros y fiables.
+                        Soy ingeniero de software en mi último año de carrera, con una especialización universitaria de dos años en ciberseguridad aplicada. Ese recorrido me permitió integrar buenas prácticas de seguridad en backend, autenticación y despliegues sin perder de vista la experiencia de usuario.
                     </p>
                     <p class="text-lg text-slate-600">
-                        Construyo y mantengo soluciones SaaS, integraciones de APIs y automatizaciones end-to-end sobre stacks Python y JavaScript. No hago pentesting profesional, pero sí aplico buenas prácticas de seguridad en backend, autenticación, protección de datos y despliegues.
+                        Trabajo en soluciones SaaS, integraciones de APIs y automatizaciones sobre Python y JavaScript. No hago pentesting profesional ni threat modeling avanzado, pero sí cuido la documentación, los flujos de datos y la operativa diaria para que cada entrega sea mantenible y honesta con sus objetivos.
                     </p>
                 </div>
                 <div class="w-full space-y-6 lg:w-1/3" data-animate>
@@ -170,7 +170,7 @@
                         <div class="rounded-3xl border border-dashed border-blue-200 bg-blue-50/60 p-6">
                             <p class="text-sm font-semibold uppercase tracking-[0.3em] text-blue-600">Colaboraciones</p>
                             <p class="mt-3 text-sm text-blue-800">
-                                Abierto a proyectos que requieran automatización de procesos, diseño de productos digitales o consultoría de ciberseguridad aplicada.
+                                Si quieres conocer más sobre estos proyectos o charlar sobre nuevas ideas técnicas, escríbeme en LinkedIn o GitHub.
                             </p>
                         </div>
                     </div>
@@ -196,12 +196,12 @@
                             </span>
                             <h3 class="text-lg font-semibold text-slate-900">Backend</h3>
                         </div>
-                        <p class="text-sm text-slate-600">APIs con Flask y FastAPI, tareas distribuidas con Celery y persistencia en MySQL y Redis sobre infraestructura contenida.</p>
+                        <p class="text-sm text-slate-600">APIs con Flask y FastAPI, tareas distribuidas con Celery y persistencia en MySQL sobre infraestructura contenerizada.</p>
                         <div class="flex flex-wrap gap-2 text-xs font-medium text-slate-500">
                             <span class="rounded-full bg-white px-3 py-1">Python</span>
                             <span class="rounded-full bg-white px-3 py-1">Flask · FastAPI</span>
                             <span class="rounded-full bg-white px-3 py-1">Celery</span>
-                            <span class="rounded-full bg-white px-3 py-1">MySQL · Redis</span>
+                            <span class="rounded-full bg-white px-3 py-1">MySQL</span>
                         </div>
                     </article>
                     <article class="group flex flex-col gap-4 rounded-3xl border border-slate-200 bg-slate-50/80 p-6 transition hover:-translate-y-1 hover:border-blue-400 hover:shadow-lg">
@@ -255,11 +255,11 @@
                             </span>
                             <h3 class="text-lg font-semibold text-slate-900">Ciberseguridad</h3>
                         </div>
-                        <p class="text-sm text-slate-600">Aplicación de buenas prácticas en backend, autenticación, gestión de secretos y protección de datos durante todo el ciclo de vida.</p>
+                        <p class="text-sm text-slate-600">Buenas prácticas en backend, autenticación y despliegues reforzadas por mi formación en ciberseguridad aplicada.</p>
                         <div class="flex flex-wrap gap-2 text-xs font-medium text-slate-500">
-                            <span class="rounded-full bg-white px-3 py-1">OWASP Top 10</span>
-                            <span class="rounded-full bg-white px-3 py-1">Hardening</span>
-                            <span class="rounded-full bg-white px-3 py-1">Gestión de accesos</span>
+                            <span class="rounded-full bg-white px-3 py-1">Buenas prácticas backend</span>
+                            <span class="rounded-full bg-white px-3 py-1">Autenticación segura</span>
+                            <span class="rounded-full bg-white px-3 py-1">Despliegues revisados</span>
                         </div>
                     </article>
                 </div>
@@ -307,7 +307,7 @@
                                     </li>
                                     <li class="flex items-start gap-3">
                                         <span class="mt-1 h-2 w-2 rounded-full bg-emerald-500"></span>
-                                        Estadísticas y exportaciones preparadas para negocio con despliegues estables en Docker.
+                                        Estadísticas y exportaciones preparadas para negocio con despliegues en Docker Compose listos para crecer con seguridad.
                                     </li>
                                 </ul>
                             </div>
@@ -353,7 +353,7 @@
                                     </li>
                                     <li class="flex items-start gap-3">
                                         <span class="mt-1 h-2 w-2 rounded-full bg-blue-500"></span>
-                                        Dashboards internos y despliegues contenerizados preparados para crecer con la empresa.
+                                        Paneles internos para el equipo financiero y despliegues contenerizados preparados para crecer con la empresa.
                                     </li>
                                 </ul>
                             </div>
@@ -385,7 +385,7 @@
                                     <svg class="h-3.5 w-3.5" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
                                         <path fill-rule="evenodd" d="M16.704 5.29a.75.75 0 0 1 .006 1.06l-7.25 7.5a.75.75 0 0 1-1.086.02L3.29 8.536a.75.75 0 0 1 1.06-1.06l4.21 4.209 6.72-6.956a.75.75 0 0 1 1.064.061Z" clip-rule="evenodd" />
                                     </svg>
-                                    Proyecto oficial Spotify
+                                    Spotify Approved
                                 </span>
                                 <span class="text-xs uppercase tracking-[0.25em] text-slate-400 font-['Space_Mono',_monospace]">Flask · OAuth 2.0 · MySQL · Spotify API</span>
                             </div>
@@ -528,13 +528,19 @@
                     </li>
                     <li class="flex items-start gap-3">
                         <span class="mt-1 h-2 w-2 rounded-full bg-blue-500"></span>
-                        Dashboards y despliegues contenerizados listos para incorporar nuevos servicios financieros.
+                        Paneles internos con métricas esenciales para el seguimiento de cobros y pendientes.
                     </li>
                 </ul>
-                <div class="rounded-2xl border border-dashed border-slate-200 bg-slate-50/80 p-4">
-                    <p class="text-xs font-semibold uppercase tracking-[0.3em] text-slate-500">Listo para más</p>
-                    <p class="mt-2 text-sm text-slate-600">Espacio reservado para diagramas, métricas y documentación ampliada.</p>
-                </div>
+                <p class="mt-4 text-sm text-slate-600">Siguiente iteración: ampliar reportes financieros internos y automatizar conciliaciones.</p>
+                <details class="rounded-2xl border border-dashed border-slate-200 bg-slate-50/80 p-4">
+                    <summary class="cursor-pointer text-xs font-semibold uppercase tracking-[0.3em] text-slate-500">Diagrama técnico</summary>
+                    <pre class="mt-3 whitespace-pre-wrap rounded-xl bg-white/80 p-4 font-['Space_Mono',_monospace] text-xs text-slate-700">Equipo Cybersur
+    ↓
+FastAPI API → MySQL
+    │
+    ├─ Celery workers → Emails y recordatorios
+    └─ Cronjobs programados → Reportes CSV</pre>
+                </details>
             </div>
         </article>
     </div>
@@ -571,13 +577,20 @@
                     </li>
                     <li class="flex items-start gap-3">
                         <span class="mt-1 h-2 w-2 rounded-full bg-amber-500"></span>
-                        Persistencia en MySQL y Redis para conservar estadísticas personalizadas y reproducir sesiones con total continuidad.
+                        Persistencia en MySQL para conservar estadísticas personalizadas y ofrecer continuidad entre sesiones.
                     </li>
                 </ul>
-                <div class="rounded-2xl border border-dashed border-slate-200 bg-slate-50/80 p-4">
-                    <p class="text-xs font-semibold uppercase tracking-[0.3em] text-slate-500">Listo para más</p>
-                    <p class="mt-2 text-sm text-slate-600">Reservado para galerías, flujos de usuarios y documentación técnica extendida.</p>
-                </div>
+                <p class="mt-4 text-sm text-slate-600">Posibles evoluciones: sumar modo colaborativo o exportaciones de insights en futuras versiones.</p>
+                <details class="rounded-2xl border border-dashed border-slate-200 bg-slate-50/80 p-4">
+                    <summary class="cursor-pointer text-xs font-semibold uppercase tracking-[0.3em] text-slate-500">Diagrama técnico</summary>
+                    <pre class="mt-3 whitespace-pre-wrap rounded-xl bg-white/80 p-4 font-['Space_Mono',_monospace] text-xs text-slate-700">Cliente web
+    ↓
+Flask API (OAuth 2.0 Spotify)
+    ↓
+MySQL → Historial y métricas
+    ↓
+Dashboards JS + Reproductor</pre>
+                </details>
             </div>
         </article>
     </div>
@@ -601,7 +614,7 @@
                     MesasYa es una plataforma <strong>SaaS en producción</strong> que digitaliza la gestión de reservas para restaurantes con múltiples sedes. Ofrece control granular de ocupación, automatización de comunicaciones y dashboards listos para el gestor.
                 </p>
                 <p>
-                    Con <strong>Flask, Celery, MySQL y Docker</strong> como base, la solución mantiene despliegues reproducibles y workflows personalizables por zona, servicio y equipo. Las analíticas y exportaciones se adaptan a las decisiones del negocio.
+                    Con <strong>Flask, Celery, MySQL y Docker</strong> como base, la solución se despliega con Docker Compose y buenas prácticas de seguridad, manteniendo workflows personalizables por zona, servicio y equipo. Las analíticas y exportaciones se adaptan a las decisiones del negocio.
                 </p>
                 <ul class="space-y-2">
                     <li class="flex items-start gap-3">
@@ -617,10 +630,16 @@
                         Indicadores de demanda, capacidad y rendimiento exportables para decisiones estratégicas.
                     </li>
                 </ul>
-                <div class="rounded-2xl border border-dashed border-slate-200 bg-slate-50/80 p-4">
-                    <p class="text-xs font-semibold uppercase tracking-[0.3em] text-slate-500">Próximos pasos</p>
-                    <p class="mt-2 text-sm text-slate-600">Integración de informes automáticos y mejoras en la experiencia del gestor para cerrar el circuito operativo.</p>
-                </div>
+                <p class="mt-4 text-sm text-slate-600">Próximos pasos: integrar informes automáticos y seguir mejorando la experiencia del gestor.</p>
+                <details class="rounded-2xl border border-dashed border-slate-200 bg-slate-50/80 p-4">
+                    <summary class="cursor-pointer text-xs font-semibold uppercase tracking-[0.3em] text-slate-500">Diagrama técnico</summary>
+                    <pre class="mt-3 whitespace-pre-wrap rounded-xl bg-white/80 p-4 font-['Space_Mono',_monospace] text-xs text-slate-700">Staff y reservas online
+    ↓
+Flask API → MySQL
+    │
+    ├─ Celery workers → Emails & SMS
+    └─ Docker Compose → Servicios coordinados</pre>
+                </details>
             </div>
         </article>
     </div>

--- a/projects.html
+++ b/projects.html
@@ -77,7 +77,7 @@
                         <ul class="mt-4 space-y-3 text-sm text-slate-600">
                             <li><a class="inline-flex items-center gap-2 text-blue-600 transition hover:text-blue-700" href="#mesasya">01 — MesasYa <span class="text-xs text-slate-400">SaaS restauración</span></a></li>
                             <li><a class="inline-flex items-center gap-2 text-blue-600 transition hover:text-blue-700" href="#kobra">02 — Kobra <span class="text-xs text-slate-400">Fintech interna</span></a></li>
-                            <li><a class="inline-flex items-center gap-2 text-blue-600 transition hover:text-blue-700" href="#beatlist">03 — BeatList <span class="text-xs text-slate-400">Proyecto oficial Spotify</span></a></li>
+                            <li><a class="inline-flex items-center gap-2 text-blue-600 transition hover:text-blue-700" href="#beatlist">03 — BeatList <span class="text-xs text-slate-400">Spotify Approved</span></a></li>
                         </ul>
                     </div>
                 </div>
@@ -99,7 +99,7 @@
                             MesasYa es un <strong>SaaS en producción</strong> que digitaliza la gestión de reservas para restaurantes con múltiples sedes. Reúne planos interactivos, reglas personalizables y notificaciones en tiempo real para que cada servicio funcione sin sorpresas.
                         </p>
                         <p>
-                            El backend basado en <strong>Flask, Celery, MySQL y Docker</strong> mantiene despliegues reproducibles y seguros. Cada restaurante configura zonas, servicios, idiomas y workflows específicos sin perder estabilidad ni trazabilidad.
+                            El backend basado en <strong>Flask, Celery, MySQL y Docker</strong> utiliza Docker Compose y buenas prácticas de seguridad. Cada restaurante configura zonas, servicios, idiomas y workflows específicos sin perder estabilidad ni trazabilidad.
                         </p>
                         <div class="rounded-3xl border border-slate-200 bg-slate-50/70 p-6">
                             <h3 class="text-sm font-semibold uppercase tracking-widest text-slate-500">Impacto operativo</h3>
@@ -115,19 +115,24 @@
                             <h3 class="text-sm font-semibold uppercase tracking-widest text-slate-500">Stack</h3>
                             <ul class="mt-4 space-y-2 text-sm text-slate-600">
                                 <li>Flask · Python</li>
-                                <li>Celery + Redis</li>
+                                <li>Celery</li>
                                 <li>MySQL administrado</li>
                                 <li>Docker Compose</li>
                             </ul>
                         </div>
                         <div class="rounded-3xl border border-dashed border-emerald-200 bg-emerald-50/70 p-6">
                             <h3 class="text-sm font-semibold uppercase tracking-widest text-emerald-700">Próximos pasos</h3>
-                            <p class="mt-2 text-sm text-slate-600">Integración de informes automáticos y mejoras en la experiencia del gestor para acelerar la toma de decisiones.</p>
+                            <p class="mt-2 text-sm text-slate-600">Integración de informes automáticos y optimización de la experiencia de gestión.</p>
                         </div>
-                        <div class="rounded-3xl border border-slate-200 bg-white/90 p-6 shadow-sm">
-                            <h3 class="text-sm font-semibold uppercase tracking-widest text-slate-500">Espacio ampliable</h3>
-                            <p class="mt-2 text-sm text-slate-600">Material listo para incluir mapas de calor, modelos de demanda y documentación de despliegue.</p>
-                        </div>
+                        <details class="rounded-3xl border border-slate-200 bg-white/90 p-6 shadow-sm">
+                            <summary class="cursor-pointer text-sm font-semibold uppercase tracking-widest text-slate-500">Esquema técnico</summary>
+                            <pre class="mt-4 whitespace-pre-wrap rounded-2xl bg-slate-50/80 p-4 font-['Space_Mono',_monospace] text-xs text-slate-700">Reservas web / staff
+    ↓
+Flask API → MySQL
+    │
+    ├─ Celery workers → Correos/SMS
+    └─ Docker Compose coordina servicios</pre>
+                        </details>
                     </aside>
                 </div>
             </div>
@@ -148,14 +153,14 @@
                             Kobra es la solución a medida que mantiene la operativa financiera de Cybersur. Automatiza facturación, cobros y recordatorios desde un backend robusto en <strong>FastAPI, Celery, MySQL y Docker</strong>.
                         </p>
                         <p>
-                            Los cronjobs programados gestionan exportaciones, limpiezas de datos y conciliaciones automáticas, mientras que los dashboards internos ofrecen visibilidad en tiempo real sobre el flujo de caja y SLA por cliente.
+                            Los cronjobs programados gestionan exportaciones, limpiezas de datos y conciliaciones automáticas. Los paneles internos priorizan métricas de cobranza y SLA por cliente para que el equipo financiero tenga claridad diaria.
                         </p>
                         <div class="rounded-3xl border border-slate-200 bg-slate-50/70 p-6">
                             <h3 class="text-sm font-semibold uppercase tracking-widest text-slate-500">Resultados clave</h3>
                             <ul class="mt-4 space-y-3">
                                 <li class="flex items-start gap-3"><span class="mt-1 h-2 w-2 rounded-full bg-blue-500"></span>Workflows de avisos y recordatorios que reducen el tiempo de seguimiento de facturas.</li>
                                 <li class="flex items-start gap-3"><span class="mt-1 h-2 w-2 rounded-full bg-blue-500"></span>Cronjobs trazables para exportaciones contables y rutinas de limpieza de datos.</li>
-                                <li class="flex items-start gap-3"><span class="mt-1 h-2 w-2 rounded-full bg-blue-500"></span>Dashboards internos con indicadores de cobro y alertas proactivas.</li>
+                                <li class="flex items-start gap-3"><span class="mt-1 h-2 w-2 rounded-full bg-blue-500"></span>Paneles internos con indicadores de cobro y alertas sobre vencimientos.</li>
                             </ul>
                         </div>
                     </article>
@@ -164,19 +169,24 @@
                             <h3 class="text-sm font-semibold uppercase tracking-widest text-slate-500">Stack</h3>
                             <ul class="mt-4 space-y-2 text-sm text-slate-600">
                                 <li>FastAPI · Python 3.11</li>
-                                <li>Celery + Redis</li>
+                                <li>Celery</li>
                                 <li>MySQL administrado</li>
                                 <li>Docker Compose</li>
                             </ul>
                         </div>
                         <div class="rounded-3xl border border-dashed border-blue-200 bg-blue-50/70 p-6">
                             <h3 class="text-sm font-semibold uppercase tracking-widest text-blue-700">Roadmap</h3>
-                            <p class="mt-2 text-sm text-slate-600">Integraciones con ERPs externos y ampliación de reportes financieros internos.</p>
+                            <p class="mt-2 text-sm text-slate-600">Ampliación de reportes financieros internos y automatización de conciliaciones.</p>
                         </div>
-                        <div class="rounded-3xl border border-slate-200 bg-white/90 p-6 shadow-sm">
-                            <h3 class="text-sm font-semibold uppercase tracking-widest text-slate-500">Material adicional</h3>
-                            <p class="mt-2 text-sm text-slate-600">Preparando diagramas de flujo, auditorías de seguridad y documentación para nuevos módulos.</p>
-                        </div>
+                        <details class="rounded-3xl border border-slate-200 bg-white/90 p-6 shadow-sm">
+                            <summary class="cursor-pointer text-sm font-semibold uppercase tracking-widest text-slate-500">Esquema técnico</summary>
+                            <pre class="mt-4 whitespace-pre-wrap rounded-2xl bg-slate-50/80 p-4 font-['Space_Mono',_monospace] text-xs text-slate-700">Equipo Cybersur
+    ↓
+FastAPI API → MySQL
+    │
+    ├─ Celery workers → Emails y recordatorios
+    └─ Cronjobs → Reportes contables</pre>
+                        </details>
                     </aside>
                 </div>
             </div>
@@ -192,7 +202,7 @@
                             <svg class="h-3.5 w-3.5" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
                                 <path fill-rule="evenodd" d="M16.704 5.29a.75.75 0 0 1 .006 1.06l-7.25 7.5a.75.75 0 0 1-1.086.02L3.29 8.536a.75.75 0 0 1 1.06-1.06l4.21 4.209 6.72-6.956a.75.75 0 0 1 1.064.061Z" clip-rule="evenodd" />
                             </svg>
-                            Proyecto oficial Spotify
+                            Spotify Approved
                         </span>
                     </div>
                     <img src="assets/beatlist-logo.svg" alt="Logo BeatList" width="140" height="140" loading="lazy" class="h-24 w-24 rounded-3xl border border-slate-100 bg-slate-50 p-4" />
@@ -200,7 +210,7 @@
                 <div class="grid gap-10 lg:grid-cols-[1.4fr,1fr]" data-animate>
                     <article class="space-y-6 text-base text-slate-600">
                         <p>
-                            BeatList es la plataforma para melómanos, curadores y creadores de contenido que buscan superar las limitaciones del gestor estándar de Spotify. Centraliza administración avanzada, descubrimiento y analítica en una experiencia fluida.
+                            BeatList es la plataforma para melómanos, curadores y creadores de contenido que necesitan más herramientas que el gestor estándar de Spotify. Centraliza administración avanzada, descubrimiento y analítica en una experiencia fluida.
                         </p>
                         <p>
                             El backend en <strong>Flask</strong> gestiona la autenticación <strong>OAuth 2.0</strong> aprobada por Spotify y accede a datos extendidos mediante su API oficial. El frontend en JavaScript dinamiza dashboards, recomendaciones y un reproductor web con animaciones suaves.
@@ -210,7 +220,7 @@
                             <ul class="mt-4 space-y-3">
                                 <li class="flex items-start gap-3"><span class="mt-1 h-2 w-2 rounded-full bg-amber-500"></span>Listas inteligentes basadas en reglas y métricas como energía o bailabilidad.</li>
                                 <li class="flex items-start gap-3"><span class="mt-1 h-2 w-2 rounded-full bg-amber-500"></span>Dashboard con tendencias temporales y hábitos de escucha segmentados por artistas y géneros.</li>
-                                <li class="flex items-start gap-3"><span class="mt-1 h-2 w-2 rounded-full bg-amber-500"></span>Reproductor web con animaciones personalizadas y continuidad entre sesiones gracias a MySQL y Redis.</li>
+                                <li class="flex items-start gap-3"><span class="mt-1 h-2 w-2 rounded-full bg-amber-500"></span>Reproductor web con animaciones personalizadas y continuidad entre sesiones gracias a MySQL.</li>
                             </ul>
                         </div>
                     </article>
@@ -221,17 +231,25 @@
                                 <li>Flask · Python</li>
                                 <li>Spotify API · OAuth 2.0</li>
                                 <li>JavaScript modular</li>
-                                <li>MySQL + Redis</li>
+                                <li>MySQL</li>
                             </ul>
                         </div>
                         <div class="rounded-3xl border border-dashed border-amber-200 bg-amber-50/70 p-6">
-                            <h3 class="text-sm font-semibold uppercase tracking-widest text-amber-700">Roadmap</h3>
-                            <p class="mt-2 text-sm text-slate-600">Modo colaborativo, exportación de insights y app móvil como siguientes iteraciones.</p>
+                            <h3 class="text-sm font-semibold uppercase tracking-widest text-amber-700">Posibles evoluciones</h3>
+                            <p class="mt-2 text-sm text-slate-600">Añadir modo colaborativo o exportación de insights en futuras versiones.</p>
                         </div>
-                        <div class="rounded-3xl border border-slate-200 bg-white/90 p-6 shadow-sm">
-                            <h3 class="text-sm font-semibold uppercase tracking-widest text-slate-500">Material extendido</h3>
-                            <p class="mt-2 text-sm text-slate-600">Espacio reservado para flujos de onboarding, mockups de dashboards y métricas avanzadas.</p>
-                        </div>
+                        <details class="rounded-3xl border border-slate-200 bg-white/90 p-6 shadow-sm">
+                            <summary class="cursor-pointer text-sm font-semibold uppercase tracking-widest text-slate-500">Esquema técnico</summary>
+                            <pre class="mt-4 whitespace-pre-wrap rounded-2xl bg-slate-50/80 p-4 font-['Space_Mono',_monospace] text-xs text-slate-700">Usuarios Spotify
+    ↓
+Flask API (OAuth 2.0)
+    ↓
+Spotify API oficial → Datos enriquecidos
+    ↓
+MySQL → Historial y métricas
+    ↓
+Frontend JS → Dashboards + reproductor</pre>
+                        </details>
                     </aside>
                 </div>
             </div>
@@ -239,8 +257,8 @@
         <section class="bg-slate-900 py-20">
             <div class="mx-auto flex max-w-5xl flex-col items-center gap-6 px-6 text-center text-white" data-animate>
                 <p class="text-xs font-semibold uppercase tracking-[0.3em] text-white/60">Conversemos</p>
-                <h2 class="text-3xl font-semibold sm:text-4xl">Si quieres conocer más sobre estos proyectos o charlar sobre nuevas ideas, contáctame en LinkedIn o GitHub.</h2>
-                <p class="max-w-3xl text-base text-white/80">Respondo personalmente cada mensaje y me gusta explorar colaboraciones donde la automatización, el SaaS y la ciberseguridad aplicada aporten valor real.</p>
+                <h2 class="text-3xl font-semibold sm:text-4xl">Si tienes curiosidad por estos proyectos o te gustaría explorar nuevas ideas técnicas, escríbeme en LinkedIn o GitHub.</h2>
+                <p class="max-w-3xl text-base text-white/80">Respondo personalmente cada mensaje y me interesa colaborar donde la automatización, el SaaS y la ciberseguridad aplicada aporten valor real.</p>
                 <div class="flex flex-wrap items-center justify-center gap-4">
                     <a href="https://www.linkedin.com/in/nicoabgv" class="inline-flex items-center gap-2 rounded-full bg-white px-6 py-3 text-sm font-semibold text-slate-900 transition hover:bg-slate-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white" target="_blank" rel="noreferrer">LinkedIn</a>
                     <a href="https://github.com/nicoabgv" class="inline-flex items-center gap-2 rounded-full border border-white/40 px-6 py-3 text-sm font-semibold text-white transition hover:border-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white" target="_blank" rel="noreferrer">GitHub</a>


### PR DESCRIPTION
## Summary
- update homepage copy, skills and collaboration messaging to highlight real experience and security training
- refresh MesasYa, Kobra and BeatList descriptions with realistic stacks, Spotify badge and expandable architecture diagrams

## Testing
- not run (static content changes)


------
https://chatgpt.com/codex/tasks/task_e_68ced809018883228159d10b6b15ac53