### PR TITLE
Add brand color accents to project listings

### DIFF
--- a/index.html
+++ b/index.html
@@ -112,7 +112,8 @@
                     <div class="mt-6 space-y-3 text-sm text-slate-600">
                         <p class="text-xs font-semibold uppercase tracking-[0.3em] text-slate-500" data-live-projects-label>Proyectos en vivo</p>
                         <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-4">
-                            <a href="https://mesasya.es" target="_blank" rel="noreferrer" class="inline-flex items-center gap-2 text-slate-700 transition hover:text-blue-600">
+                            <a href="https://mesasya.es" target="_blank" rel="noreferrer" class="inline-flex items-center gap-3 text-[#1D494F] transition hover:text-[#589E8C]">
+                                <span class="inline-flex h-6 w-6 items-center justify-center rounded-full bg-[#9DE1C1]/30 text-[10px] font-semibold uppercase tracking-wide text-[#1D494F]">MY</span>
                                 <span class="text-base" data-live-project-link="mesasya">→ MesasYa – Plataforma SaaS de gestión de reservas para restaurantes.</span>
                                 <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
                                     <path d="M5 12h14" />
@@ -127,7 +128,8 @@
                                     <path d="m12 5 7 7-7 7" />
                                 </svg>
                             </a>
-                            <a href="https://beatlist.es" target="_blank" rel="noreferrer" class="inline-flex items-center gap-2 text-slate-700 transition hover:text-blue-600">
+                            <a href="https://beatlist.es" target="_blank" rel="noreferrer" class="inline-flex items-center gap-3 text-[#111827] transition hover:text-[#1f2937]">
+                                <span class="inline-flex h-6 w-6 items-center justify-center rounded-full border border-[#111827]/60 bg-white text-[10px] font-semibold uppercase tracking-wide text-[#111827]">BL</span>
                                 <span class="text-base" data-live-project-link="beatlist">→ BeatList – Estadísticas y gestión avanzada de playlists de Spotify.</span>
                                 <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
                                     <path d="M5 12h14" />
@@ -316,7 +318,7 @@
                 </div>
                 <div class="space-y-12">
                     <article class="flex flex-col gap-10 rounded-3xl border border-slate-200 bg-white/90 p-8 shadow-lg shadow-slate-900/5 transition hover:-translate-y-1 hover:shadow-xl lg:flex-row" data-animate>
-                        <figure class="flex w-full items-center justify-center rounded-2xl border border-slate-100 bg-slate-50/80 p-6 lg:w-64">
+                        <figure class="flex w-full items-center justify-center rounded-2xl border border-[#9DE1C1]/70 bg-[#F4FFF9] p-6 lg:w-64">
                             <img src="assets/mesasya-logo.svg" alt="Identidad del proyecto MesasYa" width="160" height="160" loading="lazy" class="h-32 w-32 object-contain" />
                         </figure>
                         <div class="flex w-full flex-col gap-6">
@@ -351,13 +353,13 @@
                                         <path d="m9 5 7 7-7 7" />
                                     </svg>
                                 </button>
-                                <a href="projects.html#mesasya" class="inline-flex items-center gap-2 text-sm font-semibold text-blue-600 transition hover:text-blue-700">
+                                <a href="projects.html#mesasya" class="inline-flex items-center gap-2 text-sm font-semibold text-[#1D494F] transition hover:text-[#589E8C]">
                                     <span data-locale-element="projects.caseStudy">Case study</span>
                                     <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
                                         <path d="m9 5 7 7-7 7" />
                                     </svg>
                                 </a>
-                                <a href="https://mesasya.es" target="_blank" rel="noreferrer" class="inline-flex items-center gap-2 rounded-full border border-slate-200 px-5 py-2.5 text-sm font-semibold text-slate-700 transition hover:border-blue-500 hover:text-blue-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600">
+                                <a href="https://mesasya.es" target="_blank" rel="noreferrer" class="inline-flex items-center gap-2 rounded-full border border-[#9DE1C1]/70 px-5 py-2.5 text-sm font-semibold text-[#1D494F] transition hover:border-[#589E8C] hover:text-[#589E8C] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#589E8C]">
                                     <span data-project-direct-link="mesasya">→ MesasYa – Plataforma SaaS de gestión de reservas para restaurantes.</span>
                                     <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
                                         <path d="M5 12h14" />
@@ -422,7 +424,7 @@
                     </article>
 
                     <article class="flex flex-col gap-10 rounded-3xl border border-slate-200 bg-white/90 p-8 shadow-lg shadow-slate-900/5 transition hover:-translate-y-1 hover:shadow-xl lg:flex-row" data-animate>
-                        <figure class="flex w-full items-center justify-center rounded-2xl border border-slate-100 bg-slate-50/80 p-6 lg:w-64">
+                        <figure class="flex w-full items-center justify-center rounded-2xl border border-[#f28d1f]/40 bg-[#FFF4E6] p-6 lg:w-64">
                             <img src="assets/kobra-logo.svg" alt="Identidad del proyecto Kobra" width="160" height="160" loading="lazy" class="h-32 w-32 object-contain" />
                         </figure>
                         <div class="flex w-full flex-col gap-6">
@@ -457,7 +459,7 @@
                                         <path d="m9 5 7 7-7 7" />
                                     </svg>
                                 </button>
-                                <a href="projects.html#kobra" class="inline-flex items-center gap-2 text-sm font-semibold text-blue-600 transition hover:text-blue-700">
+                                <a href="projects.html#kobra" class="inline-flex items-center gap-2 text-sm font-semibold text-[#f28d1f] transition hover:text-[#c46f12]">
                                     <span data-locale-element="projects.caseStudy">Case study</span>
                                     <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
                                         <path d="m9 5 7 7-7 7" />
@@ -468,7 +470,7 @@
                     </article>
 
                     <article class="flex flex-col gap-10 rounded-3xl border border-slate-200 bg-white/90 p-8 shadow-lg shadow-slate-900/5 transition hover:-translate-y-1 hover:shadow-xl lg:flex-row" data-animate>
-                        <figure class="flex w-full items-center justify-center rounded-2xl border border-slate-100 bg-slate-50/80 p-6 lg:w-64">
+                        <figure class="flex w-full items-center justify-center rounded-2xl border border-[#111827]/20 bg-[#F7F7FB] p-6 lg:w-64">
                             <img src="assets/beatlist-logo.svg" alt="Identidad del proyecto BeatList" width="160" height="160" loading="lazy" class="h-32 w-32 object-contain" />
                         </figure>
                         <div class="flex w-full flex-col gap-6">
@@ -509,13 +511,13 @@
                                         <path d="m9 5 7 7-7 7" />
                                     </svg>
                                 </button>
-                                <a href="projects.html#beatlist" class="inline-flex items-center gap-2 text-sm font-semibold text-blue-600 transition hover:text-blue-700">
+                                <a href="projects.html#beatlist" class="inline-flex items-center gap-2 text-sm font-semibold text-[#111827] transition hover:text-[#1f2937]">
                                     <span data-locale-element="projects.caseStudy">Case study</span>
                                     <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
                                         <path d="m9 5 7 7-7 7" />
                                     </svg>
                                 </a>
-                                <a href="https://beatlist.es" target="_blank" rel="noreferrer" class="inline-flex items-center gap-2 rounded-full border border-slate-200 px-5 py-2.5 text-sm font-semibold text-slate-700 transition hover:border-blue-500 hover:text-blue-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600">
+                                <a href="https://beatlist.es" target="_blank" rel="noreferrer" class="inline-flex items-center gap-2 rounded-full border border-[#111827]/30 px-5 py-2.5 text-sm font-semibold text-[#111827] transition hover:border-[#1f2937] hover:text-[#1f2937] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#1f2937]">
                                     <span data-project-direct-link="beatlist">→ BeatList – Estadísticas y gestión avanzada de playlists de Spotify.</span>
                                     <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
                                         <path d="M5 12h14" />

--- a/projects.html
+++ b/projects.html
@@ -99,7 +99,7 @@
                         <p class="text-xs font-semibold uppercase tracking-[0.3em] text-slate-500">Case study 01</p>
                         <h2 class="text-3xl font-semibold text-slate-900 sm:text-4xl">MesasYa — SaaS de reservas multi-sede</h2>
                     </div>
-                    <img src="assets/mesasya-logo.svg" alt="Logo MesasYa" width="140" height="140" loading="lazy" class="h-24 w-24 rounded-3xl border border-slate-100 bg-slate-50 p-4" />
+                    <img src="assets/mesasya-logo.svg" alt="Logo MesasYa" width="140" height="140" loading="lazy" class="h-24 w-24 rounded-3xl border border-[#9DE1C1]/70 bg-[#F4FFF9] p-4" />
                 </div>
                 <div class="grid gap-10 lg:grid-cols-[1.4fr,1fr]" data-animate>
                     <article class="space-y-6 text-base text-slate-600">
@@ -109,9 +109,9 @@
                         <p>
                             El backend basado en <strong data-i18n="stack.flaskcelery"></strong> utiliza Docker Compose y buenas prácticas de seguridad. Cada restaurante configura zonas, servicios, idiomas y workflows específicos sin perder estabilidad ni trazabilidad.
                         </p>
-                        <div class="rounded-3xl border border-slate-200 bg-white/80 p-5 shadow-sm">
-                            <p class="text-xs font-semibold uppercase tracking-[0.3em] text-slate-500" data-direct-access-label>Acceso directo</p>
-                            <a href="https://mesasya.es" target="_blank" rel="noreferrer" class="mt-3 inline-flex items-center gap-2 text-sm font-semibold text-slate-700 transition hover:text-blue-600">
+                        <div class="rounded-3xl border border-[#9DE1C1]/60 bg-[#F4FFF9] p-5 shadow-sm">
+                            <p class="text-xs font-semibold uppercase tracking-[0.3em] text-[#1D494F]" data-direct-access-label>Acceso directo</p>
+                            <a href="https://mesasya.es" target="_blank" rel="noreferrer" class="mt-3 inline-flex items-center gap-2 text-sm font-semibold text-[#1D494F] transition hover:text-[#589E8C]">
                                 <span data-direct-access-link="mesasya">→ MesasYa – Plataforma SaaS de gestión de reservas para restaurantes.</span>
                                 <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
                                     <path d="M5 12h14" />
@@ -227,7 +227,7 @@ FastAPI + Uvicorn → MySQL
                         <p class="text-xs font-semibold uppercase tracking-[0.3em] text-slate-500">Case study 03</p>
                         <h2 class="text-3xl font-semibold text-slate-900 sm:text-4xl">Kobra — Plataforma financiera para Cybersur</h2>
                     </div>
-                    <img src="assets/kobra-logo.svg" alt="Logo Kobra" width="140" height="140" loading="lazy" class="h-24 w-24 rounded-3xl border border-slate-100 bg-slate-50 p-4" />
+                    <img src="assets/kobra-logo.svg" alt="Logo Kobra" width="140" height="140" loading="lazy" class="h-24 w-24 rounded-3xl border border-[#f28d1f]/50 bg-[#FFF4E6] p-4" />
                 </div>
                 <div class="grid gap-10 lg:grid-cols-[1.4fr,1fr]" data-animate>
                     <article class="space-y-6 text-base text-slate-600">
@@ -287,7 +287,7 @@ FastAPI API → MySQL
                             <span data-locale-element="projects.beatlist.approval">Spotify Approved</span>
                         </span>
                     </div>
-                    <img src="assets/beatlist-logo.svg" alt="Logo BeatList" width="140" height="140" loading="lazy" class="h-24 w-24 rounded-3xl border border-slate-100 bg-slate-50 p-4" />
+                    <img src="assets/beatlist-logo.svg" alt="Logo BeatList" width="140" height="140" loading="lazy" class="h-24 w-24 rounded-3xl border border-[#111827]/25 bg-[#F7F7FB] p-4" />
                 </div>
                 <div class="grid gap-10 lg:grid-cols-[1.4fr,1fr]" data-animate>
                     <article class="space-y-6 text-base text-slate-600">
@@ -297,9 +297,9 @@ FastAPI API → MySQL
                         <p>
                             El backend en <strong>Flask</strong> gestiona la autenticación <strong data-i18n="stack.oauth"></strong> aprobada por Spotify, coordina análisis pesados con <strong>Celery</strong> y accede a datos extendidos mediante la <strong data-i18n="stack.spotifyapi"></strong>. El frontend en JavaScript dinamiza dashboards, recomendaciones y un reproductor web con animaciones suaves.
                         </p>
-                        <div class="rounded-3xl border border-slate-200 bg-white/80 p-5 shadow-sm">
-                            <p class="text-xs font-semibold uppercase tracking-[0.3em] text-slate-500" data-direct-access-label>Acceso directo</p>
-                            <a href="https://beatlist.es" target="_blank" rel="noreferrer" class="mt-3 inline-flex items-center gap-2 text-sm font-semibold text-slate-700 transition hover:text-blue-600">
+                        <div class="rounded-3xl border border-[#111827]/25 bg-[#F7F7FB] p-5 shadow-sm">
+                            <p class="text-xs font-semibold uppercase tracking-[0.3em] text-[#111827]" data-direct-access-label>Acceso directo</p>
+                            <a href="https://beatlist.es" target="_blank" rel="noreferrer" class="mt-3 inline-flex items-center gap-2 text-sm font-semibold text-[#111827] transition hover:text-[#1f2937]">
                                 <span data-direct-access-link="beatlist">→ BeatList – Estadísticas y gestión avanzada de playlists de Spotify.</span>
                                 <svg class="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
                                     <path d="M5 12h14" />


### PR DESCRIPTION
## Summary
- add custom color accents for each project link and card in the home page
- align project detail sections with matching logo frames and direct access styling

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68f9f06452c88322bfe445c9400fc878